### PR TITLE
Fix nav bar for small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -485,22 +485,22 @@ body {
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     .header {
         display: none;
     }
 
     .menu-toggle {
-        display: flex;
+        display: flex !important;
+    }
+    
+    .main-content {
+        padding-top: 5rem; /* Add space for fixed menu toggle */
     }
 
     .gallery-grid {
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 1rem;
-    }
-
-    .main-content {
-        padding: 1rem 0.5rem;
     }
 
     .logo-container {
@@ -545,7 +545,7 @@ body {
     }
 }
 
-@media (min-width: 769px) and (max-width: 1024px) {
+@media (min-width: 1025px) and (max-width: 1399px) {
     .gallery-grid {
         grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     }


### PR DESCRIPTION
Adjust responsive breakpoints and menu toggle visibility to correctly display the mobile sidebar navigation on small and medium screens.

The existing mobile navigation sidebar was not appearing on small screens because the `.header` was hidden, but the `.menu-toggle` button was not reliably displayed due to conflicting CSS rules and an insufficient `max-width` breakpoint. This PR extends the mobile breakpoint and ensures the toggle button is visible, activating the pre-existing sidebar functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3189a43-34fb-426d-a5f1-b9b511227dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3189a43-34fb-426d-a5f1-b9b511227dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

